### PR TITLE
Set reward per sec to 0 for stopped rewarder

### DIFF
--- a/src/rewarders/BaseRewarder.sol
+++ b/src/rewarders/BaseRewarder.sol
@@ -370,8 +370,7 @@ abstract contract BaseRewarder is Ownable2StepUpgradeable, Clone, IBaseRewarder 
         _totalUnclaimedRewards = totalUnclaimedRewards;
 
         _rewarder.updateAccDebtPerShare(totalSupply, totalRewards);
-
-        if (startTimestamp != block.timestamp) _rewarder.lastUpdateTimestamp = startTimestamp;
+        _rewarder.lastUpdateTimestamp = startTimestamp;
 
         emit RewardParameterUpdated(rewardPerSecond, startTimestamp, endTimestamp);
     }

--- a/src/rewarders/BaseRewarder.sol
+++ b/src/rewarders/BaseRewarder.sol
@@ -190,6 +190,8 @@ abstract contract BaseRewarder is Ownable2StepUpgradeable, Clone, IBaseRewarder 
         _totalUnclaimedRewards += totalPendingRewards;
         _rewarder.updateAccDebtPerShare(totalSupply, totalPendingRewards);
 
+        _setRewardParameters(0, block.timestamp, 0);
+
         _isStopped = true;
 
         emit Stopped();

--- a/test/VeMoe.t.sol
+++ b/test/VeMoe.t.sol
@@ -1120,6 +1120,8 @@ contract VeMoeTest is Test {
         vm.expectRevert(IBaseRewarder.BaseRewarder__ZeroAmount.selector);
         bribes1.sweep(token6d, address(this));
 
+        vm.warp(block.timestamp + 1 days);
+
         pids[0] = 1;
         bribes[0] = IVeMoeRewarder(address(0));
 


### PR DESCRIPTION
Fix the rewarders that are stopped mid-emission by also setting the rewards per sec to 0.