### PR TITLE
V2.2 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,7 @@
 [submodule "lib/dexv2"]
 	path = lib/dexv2
 	url = https://github.com/traderjoe-xyz/dexv2
+	branch = v2.2
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,6 +1,6 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-@openzeppelin/=lib/openzeppelin-contracts/
-@openzeppelin-upgradeable/=lib/openzeppelin-contracts-upgradeable/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
 @tj-dexv2/=lib/dexv2/
 @solmate/=lib/solmate/

--- a/script/fuji/0_DeployProtocol.s.sol
+++ b/script/fuji/0_DeployProtocol.s.sol
@@ -154,6 +154,7 @@ contract DeployProtocolScript is Script {
                 IMoe(moeAddress),
                 IVeMoe(proxies.veMoe),
                 IRewarderFactory(proxies.rewarderFactory),
+                ILBFactory(address(0)),
                 Parameters.treasuryPercent * 1e18 / sumEmissionShare
             );
 

--- a/script/fuji/0_DeployProtocol.s.sol
+++ b/script/fuji/0_DeployProtocol.s.sol
@@ -154,7 +154,7 @@ contract DeployProtocolScript is Script {
                 IMoe(moeAddress),
                 IVeMoe(proxies.veMoe),
                 IRewarderFactory(proxies.rewarderFactory),
-                ILBFactory(address(0)),
+                address(0),
                 Parameters.treasuryPercent * 1e18 / sumEmissionShare
             );
 

--- a/script/mantle/0_DeployProtocol.s.sol
+++ b/script/mantle/0_DeployProtocol.s.sol
@@ -139,6 +139,7 @@ contract DeployProtocolScript is Script {
                 IMoe(moeAddress),
                 IVeMoe(proxies.veMoe),
                 IRewarderFactory(proxies.rewarderFactory),
+                ILBFactory(address(0)),
                 Parameters.treasuryPercent * 1e18 / sumEmissionShare
             );
 

--- a/script/mantle/0_DeployProtocol.s.sol
+++ b/script/mantle/0_DeployProtocol.s.sol
@@ -139,7 +139,7 @@ contract DeployProtocolScript is Script {
                 IMoe(moeAddress),
                 IVeMoe(proxies.veMoe),
                 IRewarderFactory(proxies.rewarderFactory),
-                ILBFactory(address(0)),
+                address(0),
                 Parameters.treasuryPercent * 1e18 / sumEmissionShare
             );
 

--- a/script/mantle/2_DeployMasterChef.s.sol
+++ b/script/mantle/2_DeployMasterChef.s.sol
@@ -40,7 +40,7 @@ contract DeployMasterChefScript is Script {
         uint256 sumEmissionShare = Parameters.liquidityMiningPercent + Parameters.treasuryPercent;
 
         masterChefImplementation = new MasterChef(
-            moe, veMoe, rewarderFactory, ILBFactory(address(0)), Parameters.treasuryPercent * 1e18 / sumEmissionShare
+            moe, veMoe, rewarderFactory, address(0), Parameters.treasuryPercent * 1e18 / sumEmissionShare
         );
 
         vm.stopBroadcast();

--- a/script/mantle/2_DeployMasterChef.s.sol
+++ b/script/mantle/2_DeployMasterChef.s.sol
@@ -39,8 +39,9 @@ contract DeployMasterChefScript is Script {
 
         uint256 sumEmissionShare = Parameters.liquidityMiningPercent + Parameters.treasuryPercent;
 
-        masterChefImplementation =
-            new MasterChef(moe, veMoe, rewarderFactory, Parameters.treasuryPercent * 1e18 / sumEmissionShare);
+        masterChefImplementation = new MasterChef(
+            moe, veMoe, rewarderFactory, ILBFactory(address(0)), Parameters.treasuryPercent * 1e18 / sumEmissionShare
+        );
 
         vm.stopBroadcast();
     }

--- a/script/mantle/3_Deploy.s.sol
+++ b/script/mantle/3_Deploy.s.sol
@@ -9,16 +9,27 @@ import "./Addresses.sol";
 import "../../src/VeMoe.sol";
 import "../../src/MasterChef.sol";
 import "../../src/MoeLens.sol";
+import "../../src/rewarders/VeMoeRewarder.sol";
+import "../../src/rewarders/MasterChefRewarder.sol";
 
 contract DeployScript is Script {
-    function run() public returns (VeMoe veMoe, MasterChef masterChef, MoeLens moeLens) {
+    function run()
+        public
+        returns (
+            VeMoe veMoe,
+            MasterChef masterChef,
+            MoeLens moeLens,
+            VeMoeRewarder veMoeRewarder,
+            MasterChefRewarder masterChefRewarder
+        )
+    {
         // add the custom chain
         setChain(
             Parameters.chainAlias,
             StdChains.ChainData({name: Parameters.chainName, chainId: Parameters.chainId, rpcUrl: Parameters.rpcUrl})
         );
 
-        vm.createSelectFork(StdChains.getChain(Parameters.chainAlias).rpcUrl, 49731291);
+        vm.createSelectFork(StdChains.getChain(Parameters.chainAlias).rpcUrl, 51235190);
 
         uint256 pk = vm.envUint("DEPLOYER_PRIVATE_KEY");
 
@@ -37,12 +48,17 @@ contract DeployScript is Script {
             IMoe(Addresses.moe),
             IVeMoe(Addresses.veMoeProxy),
             IRewarderFactory(Addresses.rewarderFactoryProxy),
+            ILBFactory(address(0)),
             Parameters.treasuryPercent * 1e18 / sumEmissionShare
         );
 
         moeLens = new MoeLens(
             IMasterChef(Addresses.masterChefProxy), IJoeStaking(Addresses.joeStakingProxy), Parameters.nativeSymbol
         );
+
+        veMoeRewarder = new VeMoeRewarder(Addresses.veMoeProxy);
+
+        masterChefRewarder = new MasterChefRewarder(Addresses.masterChefProxy);
 
         vm.stopBroadcast();
     }

--- a/script/mantle/3_Deploy.s.sol
+++ b/script/mantle/3_Deploy.s.sol
@@ -48,7 +48,7 @@ contract DeployScript is Script {
             IMoe(Addresses.moe),
             IVeMoe(Addresses.veMoeProxy),
             IRewarderFactory(Addresses.rewarderFactoryProxy),
-            ILBFactory(address(0)),
+            address(0),
             Parameters.treasuryPercent * 1e18 / sumEmissionShare
         );
 

--- a/script/mantle/Addresses.sol
+++ b/script/mantle/Addresses.sol
@@ -13,14 +13,14 @@ library Addresses {
     address public constant joe = 0x371c7ec6D8039ff7933a2AA28EB827Ffe1F52f07;
 
     // Implementations
-    address public constant masterChefImplementation = 0x76D8d0e37F697Cc95c87F0Ba9512701cf19b0Cb5;
+    address public constant masterChefImplementation = 0xEB1D0861f15675F6550F167388479491fA73cE2a;
     address public constant moeStakingImplementation = 0xE92249760e1443FbBeA45B03f607Ba84471Fa793;
-    address public constant veMoeImplementation = 0x240616e2448e078934863fB6eb5133834BF14Ef1;
+    address public constant veMoeImplementation = 0x4CEabD15438b52CE553d740b27Ec2cd27f920E4C;
     address public constant stableMoeImplementation = 0x5Ab84d68892E565a8bF077A39481D5f69edAAC02;
     address public constant joeStakingImplementation = 0x7fb0Fc8514D817c655276A2895307176F253D303;
     address public constant rewarderFactoryImplementation = 0x18d3F4Df4959503C5F2C8B562da3118939890025;
-    address public constant masterChefRewarderImplementation = 0xcc076c7c657DCAfC738991297903610896d2E938;
-    address public constant veMoeRewarderImplementation = 0x151B82CA3a0c9dA9Dfde200F9C527cD89dd6aea8;
+    address public constant masterChefRewarderImplementation = 0x6B9B717e56bB1C432115d748FC6Cf40cbd132B33;
+    address public constant veMoeRewarderImplementation = 0x8Eb08451b9062fFFc0FC62aD9d54669c931ee254;
     address public constant joeStakingRewarderImplementation = 0x1D16326BA904546b4DA88d357Dd556Ebe1f08dD6;
 
     // Proxies
@@ -45,7 +45,7 @@ library Addresses {
 
     // Helpers
     address public constant moeQuoter = 0x72B507A4799815aDc30083925f748210E92B59f4;
-    address public constant moeLens = 0xAa61e8db8983582BfD7786FEa681E7bB237698ba;
+    address public constant moeLens = 0xDAB59901C1CD2C43A63b575704d150c777DA1F55;
     address public constant moeHelper = 0x3f0E209213d93508a451d521fD758cBc3B78cA90;
 
     // FeeManager

--- a/src/JoeStaking.sol
+++ b/src/JoeStaking.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 import {Math} from "./libraries/Math.sol";
 import {Amounts} from "./libraries/Amounts.sol";

--- a/src/MasterChef.sol
+++ b/src/MasterChef.sol
@@ -338,8 +338,8 @@ contract MasterChef is Ownable2StepUpgradeable, IMasterChef {
      * @param extraRewarder The extra rewarder of the farm.
      */
     function add(IERC20 token, IMasterChefRewarder extraRewarder) external override {
-        if (address(_lbFactory) != address(0) && _lbFactory.isDefaultLBHooks(ILBHooks(msg.sender))) {
-            if (address(token) != msg.sender) revert MasterChef__InvalidToken();
+        if (address(token) == msg.sender && address(_lbFactory) != address(0)) {
+            if (!_lbFactory.isDefaultLBHooks(ILBHooks(msg.sender))) revert MasterChef__NotDefaultLBHooks();
         } else {
             _checkOwner();
         }

--- a/src/MasterChef.sol
+++ b/src/MasterChef.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 import {Math} from "./libraries/Math.sol";
 import {Rewarder} from "./libraries/Rewarder.sol";

--- a/src/StableMoe.sol
+++ b/src/StableMoe.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 import {Rewarder} from "./libraries/Rewarder.sol";
 import {IMoeStaking} from "./interfaces/IMoeStaking.sol";

--- a/src/VeMoe.sol
+++ b/src/VeMoe.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {FixedPointMathLib} from "@solmate/src/utils/FixedPointMathLib.sol";
 
 import {Math} from "./libraries/Math.sol";

--- a/src/interfaces/IMasterChef.sol
+++ b/src/interfaces/IMasterChef.sol
@@ -18,7 +18,7 @@ interface IMasterChef {
     error MasterChef__NotMasterchefRewarder();
     error MasterChef__CannotRenounceOwnership();
     error MasterChef__MintFailed();
-    error MasterChef__InvalidToken();
+    error MasterChef__NotDefaultLBHooks();
 
     struct Farm {
         Amounts.Parameter amounts;

--- a/src/interfaces/IMasterChef.sol
+++ b/src/interfaces/IMasterChef.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ILBFactory} from "@tj-dexv2/src/interfaces/ILBFactory.sol";
 
 import {IMasterChefRewarder} from "./IMasterChefRewarder.sol";
 import {IMoe} from "./IMoe.sol";
@@ -17,6 +18,7 @@ interface IMasterChef {
     error MasterChef__NotMasterchefRewarder();
     error MasterChef__CannotRenounceOwnership();
     error MasterChef__MintFailed();
+    error MasterChef__InvalidToken();
 
     struct Farm {
         Amounts.Parameter amounts;
@@ -71,6 +73,8 @@ interface IMasterChef {
     function getTreasuryShare() external view returns (uint256);
 
     function getRewarderFactory() external view returns (IRewarderFactory);
+
+    function getLBFactory() external view returns (ILBFactory);
 
     function getVeMoe() external view returns (IVeMoe);
 

--- a/src/interfaces/IMasterChef.sol
+++ b/src/interfaces/IMasterChef.sol
@@ -17,7 +17,6 @@ interface IMasterChef {
     error MasterChef__NotMasterchefRewarder();
     error MasterChef__CannotRenounceOwnership();
     error MasterChef__MintFailed();
-    error MasterChef__NotDefaultLBHooks();
 
     struct Farm {
         Amounts.Parameter amounts;

--- a/src/interfaces/IMasterChef.sol
+++ b/src/interfaces/IMasterChef.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ILBFactory} from "@tj-dexv2/src/interfaces/ILBFactory.sol";
 
 import {IMasterChefRewarder} from "./IMasterChefRewarder.sol";
 import {IMoe} from "./IMoe.sol";
@@ -74,7 +73,7 @@ interface IMasterChef {
 
     function getRewarderFactory() external view returns (IRewarderFactory);
 
-    function getLBFactory() external view returns (ILBFactory);
+    function getLBHooksManager() external view returns (address);
 
     function getVeMoe() external view returns (IVeMoe);
 

--- a/src/rewarders/BaseRewarder.sol
+++ b/src/rewarders/BaseRewarder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Clone} from "@tj-dexv2/src/libraries/Clone.sol";
 

--- a/src/rewarders/RewarderFactory.sol
+++ b/src/rewarders/RewarderFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/contracts/access/Ownable2StepUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {ImmutableClone} from "@tj-dexv2/src/libraries/ImmutableClone.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/test/JoeStaking.t.sol
+++ b/test/JoeStaking.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 import "../src/JoeStaking.sol";
 import "../src/rewarders/JoeStakingRewarder.sol";

--- a/test/MasterChef.t.sol
+++ b/test/MasterChef.t.sol
@@ -307,17 +307,21 @@ contract MasterChefTest is Test {
         vm.prank(alice);
         masterChef.add(tokenA, IMasterChefRewarder(address(0)));
 
+        vm.prank(address(tokenA));
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, tokenA));
+        masterChef.add(tokenA, IMasterChefRewarder(address(0)));
+
         ILBFactory lbFactory = ILBFactory(address(new MockLBFactory()));
         masterChef = new MasterChef(moe, IVeMoe(address(veMoe)), factory, lbFactory, 0);
 
         vm.prank(address(tokenA));
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, tokenA));
+        vm.expectRevert(IMasterChef.MasterChef__NotDefaultLBHooks.selector);
         masterChef.add(tokenA, IMasterChefRewarder(address(0)));
 
         MockLBFactory(address(lbFactory)).setDefaultLBHooks(ILBHooks(address(tokenA)), true);
 
         vm.prank(address(tokenA));
-        vm.expectRevert(IMasterChef.MasterChef__InvalidToken.selector);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, tokenA));
         masterChef.add(tokenB, IMasterChefRewarder(address(0)));
 
         vm.prank(address(tokenA));
@@ -326,7 +330,7 @@ contract MasterChefTest is Test {
         MockLBFactory(address(lbFactory)).setDefaultLBHooks(ILBHooks(address(tokenA)), false);
 
         vm.prank(address(tokenA));
-        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, tokenA));
+        vm.expectRevert(IMasterChef.MasterChef__NotDefaultLBHooks.selector);
         masterChef.add(tokenA, IMasterChefRewarder(address(0)));
     }
 

--- a/test/MasterChef.t.sol
+++ b/test/MasterChef.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
 
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import "../src/transparent/TransparentUpgradeableProxy2Step.sol";
 import "../src/MasterChef.sol";

--- a/test/MasterChef.t.sol
+++ b/test/MasterChef.t.sol
@@ -44,7 +44,8 @@ contract MasterChefTest is Test {
 
         moe = IMoe(address(new Moe(masterChefAddress, 0, type(uint256).max)));
 
-        masterChef = new MasterChef(moe, IVeMoe(address(veMoe)), IRewarderFactory(factoryAddress), 0);
+        masterChef =
+            new MasterChef(moe, IVeMoe(address(veMoe)), IRewarderFactory(factoryAddress), ILBFactory(address(0)), 0);
 
         TransparentUpgradeableProxy2Step proxy = new TransparentUpgradeableProxy2Step(
             address(masterChef),
@@ -305,6 +306,28 @@ contract MasterChefTest is Test {
         vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, alice));
         vm.prank(alice);
         masterChef.add(tokenA, IMasterChefRewarder(address(0)));
+
+        ILBFactory lbFactory = ILBFactory(address(new MockLBFactory()));
+        masterChef = new MasterChef(moe, IVeMoe(address(veMoe)), factory, lbFactory, 0);
+
+        vm.prank(address(tokenA));
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, tokenA));
+        masterChef.add(tokenA, IMasterChefRewarder(address(0)));
+
+        MockLBFactory(address(lbFactory)).setDefaultLBHooks(ILBHooks(address(tokenA)), true);
+
+        vm.prank(address(tokenA));
+        vm.expectRevert(IMasterChef.MasterChef__InvalidToken.selector);
+        masterChef.add(tokenB, IMasterChefRewarder(address(0)));
+
+        vm.prank(address(tokenA));
+        masterChef.add(tokenA, IMasterChefRewarder(address(0)));
+
+        MockLBFactory(address(lbFactory)).setDefaultLBHooks(ILBHooks(address(tokenA)), false);
+
+        vm.prank(address(tokenA));
+        vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, tokenA));
+        masterChef.add(tokenA, IMasterChefRewarder(address(0)));
     }
 
     function test_EmergencyWithdrawal() public {
@@ -368,7 +391,7 @@ contract MasterChefTest is Test {
         address masterChefAddress = computeCreateAddress(address(this), nonce + 2);
 
         moe = IMoe(address(new Moe(masterChefAddress, 0, type(uint256).max)));
-        masterChef = new MasterChef(moe, IVeMoe(address(veMoe)), factory, 0.3e18);
+        masterChef = new MasterChef(moe, IVeMoe(address(veMoe)), factory, ILBFactory(address(0)), 0.3e18);
 
         TransparentUpgradeableProxy2Step proxy = new TransparentUpgradeableProxy2Step(
             address(masterChef),
@@ -433,9 +456,9 @@ contract MasterChefTest is Test {
         assertEq(masterChef.getTreasury(), address(1), "test_TreasuryShare::22");
 
         vm.expectRevert(IMasterChef.MasterChef__InvalidShares.selector);
-        new MasterChef(moe, IVeMoe(address(veMoe)), factory, 1e18 + 1);
+        new MasterChef(moe, IVeMoe(address(veMoe)), factory, ILBFactory(address(0)), 1e18 + 1);
 
-        new MasterChef(moe, IVeMoe(address(veMoe)), factory, 1e18);
+        new MasterChef(moe, IVeMoe(address(veMoe)), factory, ILBFactory(address(0)), 1e18);
     }
 
     function test_ExtraRewarder() public {
@@ -521,5 +544,13 @@ contract MasterChefTest is Test {
         assertEq(moe.balanceOf(address(bob)), moeRewardBob[0], "test_ExtraRewarder::22");
         assertEq(rewardToken0.balanceOf(address(bob)), extraRewardBob[0], "test_ExtraRewarder::23");
         assertEq(rewardToken1.balanceOf(address(bob)), extraRewardBob[1], "test_ExtraRewarder::24");
+    }
+}
+
+contract MockLBFactory {
+    mapping(ILBHooks => bool) public isDefaultLBHooks;
+
+    function setDefaultLBHooks(ILBHooks hooks, bool isDefault) external {
+        isDefaultLBHooks[hooks] = isDefault;
     }
 }

--- a/test/MasterChefRewarder.t.sol
+++ b/test/MasterChefRewarder.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
 
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import "../src/interfaces/IMasterChef.sol";
 import "../src/rewarders/MasterChefRewarder.sol";

--- a/test/Upgrade.t.sol
+++ b/test/Upgrade.t.sol
@@ -11,7 +11,7 @@ contract UpgradeTest is Test {
     function test_UpgradeVeMoe() public {
         DeployScript deployer = new DeployScript();
 
-        (VeMoe newVeMoeImplementation, MasterChef newMasterChefImplementation,) = deployer.run();
+        (VeMoe newVeMoeImplementation, MasterChef newMasterChefImplementation,,,) = deployer.run();
 
         assertEq(
             address(IVeMoe(Addresses.veMoeProxy).getMoeStaking()),

--- a/test/VeMoe.t.sol
+++ b/test/VeMoe.t.sol
@@ -50,7 +50,8 @@ contract VeMoeTest is Test {
         address factoryAddress = computeCreateAddress(address(this), nonce + 6);
 
         staking = new MoeStaking(moe, IVeMoe(veMoeAddress), IStableMoe(sMoe));
-        masterChef = new MasterChef(moe, IVeMoe(veMoeAddress), IRewarderFactory(factoryAddress), 0);
+        masterChef =
+            new MasterChef(moe, IVeMoe(veMoeAddress), IRewarderFactory(factoryAddress), ILBFactory(address(0)), 0);
         veMoe = new VeMoe(
             IMoeStaking(stakingAddress), IMasterChef(masterChefAddress), IRewarderFactory(factoryAddress), 100e18
         );

--- a/test/VeMoe.t.sol
+++ b/test/VeMoe.t.sol
@@ -50,8 +50,7 @@ contract VeMoeTest is Test {
         address factoryAddress = computeCreateAddress(address(this), nonce + 6);
 
         staking = new MoeStaking(moe, IVeMoe(veMoeAddress), IStableMoe(sMoe));
-        masterChef =
-            new MasterChef(moe, IVeMoe(veMoeAddress), IRewarderFactory(factoryAddress), ILBFactory(address(0)), 0);
+        masterChef = new MasterChef(moe, IVeMoe(veMoeAddress), IRewarderFactory(factoryAddress), address(0), 0);
         veMoe = new VeMoe(
             IMoeStaking(stakingAddress), IMasterChef(masterChefAddress), IRewarderFactory(factoryAddress), 100e18
         );

--- a/test/VeMoe.t.sol
+++ b/test/VeMoe.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import "forge-std/Test.sol";
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import "../src/transparent/TransparentUpgradeableProxy2Step.sol";
 import "../src/VeMoe.sol";
@@ -1119,6 +1119,8 @@ contract VeMoeTest is Test {
 
         vm.expectRevert(IBaseRewarder.BaseRewarder__ZeroAmount.selector);
         bribes1.sweep(token6d, address(this));
+
+        vm.warp(block.timestamp + 1 days);
 
         pids[0] = 1;
         bribes[0] = IVeMoeRewarder(address(0));


### PR DESCRIPTION
This PR mainly add the support for v2.2 hooks and allows the `LBHooksManager` to create farms.