### PR TITLE
Rewarder V2

### DIFF
--- a/src/libraries/Constants.sol
+++ b/src/libraries/Constants.sol
@@ -8,6 +8,7 @@ pragma solidity ^0.8.20;
 library Constants {
     uint256 internal constant ACC_PRECISION_BITS = 64;
     uint256 internal constant PRECISION = 1e18;
+    uint8 internal constant NEW_ACC_PRECISION_BITS = 128;
 
     uint256 internal constant MAX_NUMBER_OF_FARMS = 32;
     uint256 internal constant MAX_NUMBER_OF_REWARDS = 32;

--- a/src/libraries/RewarderV2.sol
+++ b/src/libraries/RewarderV2.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Uint256x256Math} from "@tj-dexv2/src/libraries/math/Uint256x256Math.sol";
+
+import {Amounts} from "./Amounts.sol";
+import {Constants} from "./Constants.sol";
+
+/**
+ * @title Rewarder Library V2
+ * @dev A library that defines various functions for calculating rewards.
+ * It takes care about the reward debt and the accumulated debt per share.
+ * Uses 128 bits of precision for the accumulated debt per share.
+ */
+library RewarderV2 {
+    using Amounts for Amounts.Parameter;
+    using Uint256x256Math for uint256;
+
+    struct Parameter {
+        uint256 lastUpdateTimestamp;
+        uint256 accDebtPerShare;
+        mapping(address => uint256) debt;
+    }
+
+    /**
+     * @dev Returns the debt associated with an amount.
+     * @param accDebtPerShare The accumulated debt per share.
+     * @param deposit The amount.
+     * @return The debt associated with the amount.
+     */
+    function getDebt(uint256 accDebtPerShare, uint256 deposit) internal pure returns (uint256) {
+        return deposit.mulShiftRoundDown(accDebtPerShare, Constants.NEW_ACC_PRECISION_BITS);
+    }
+
+    /**
+     * @dev Returns the debt per share associated with a total deposit and total rewards.
+     * @param totalDeposit The total deposit.
+     * @param totalRewards The total rewards.
+     * @return The debt per share associated with the total deposit and total rewards.
+     */
+    function getDebtPerShare(uint256 totalDeposit, uint256 totalRewards) internal pure returns (uint256) {
+        return totalDeposit == 0 ? 0 : totalRewards.shiftDivRoundDown(Constants.NEW_ACC_PRECISION_BITS, totalDeposit);
+    }
+
+    /**
+     * @dev Returns the total rewards to emit.
+     * If the end timestamp is in the past, the rewards are calculated up to the end timestamp.
+     * If the last update timestamp is in the future, it will return 0.
+     * @param rewarder The storage pointer to the rewarder.
+     * @param rewardPerSecond The reward per second.
+     * @param endTimestamp The end timestamp.
+     * @param totalSupply The total supply.
+     * @return The total rewards.
+     */
+    function getTotalRewards(
+        Parameter storage rewarder,
+        uint256 rewardPerSecond,
+        uint256 endTimestamp,
+        uint256 totalSupply
+    ) internal view returns (uint256) {
+        if (totalSupply == 0) return 0;
+
+        uint256 lastUpdateTimestamp = rewarder.lastUpdateTimestamp;
+        uint256 timestamp = block.timestamp > endTimestamp ? endTimestamp : block.timestamp;
+
+        return timestamp > lastUpdateTimestamp ? (timestamp - lastUpdateTimestamp) * rewardPerSecond : 0;
+    }
+
+    /**
+     * @dev Returns the total rewards to emit.
+     * @param rewarder The storage pointer to the rewarder.
+     * @param rewardPerSecond The reward per second.
+     * @param totalSupply The total supply.
+     * @return The total rewards.
+     */
+    function getTotalRewards(Parameter storage rewarder, uint256 rewardPerSecond, uint256 totalSupply)
+        internal
+        view
+        returns (uint256)
+    {
+        return getTotalRewards(rewarder, rewardPerSecond, block.timestamp, totalSupply);
+    }
+
+    /**
+     * @dev Returns the pending reward of an account.
+     * @param rewarder The storage pointer to the rewarder.
+     * @param amounts The storage pointer to the amounts.
+     * @param account The address of the account.
+     * @param totalRewards The total rewards.
+     * @return The pending reward of the account.
+     */
+    function getPendingReward(
+        Parameter storage rewarder,
+        Amounts.Parameter storage amounts,
+        address account,
+        uint256 totalRewards
+    ) internal view returns (uint256) {
+        return getPendingReward(rewarder, account, amounts.getAmountOf(account), amounts.getTotalAmount(), totalRewards);
+    }
+
+    /**
+     * @dev Returns the pending reward of an account.
+     * If the balance of the account is 0, it will always return 0.
+     * @param rewarder The storage pointer to the rewarder.
+     * @param account The address of the account.
+     * @param balance The balance of the account.
+     * @param totalSupply The total supply.
+     * @param totalRewards The total rewards.
+     * @return The pending reward of the account.
+     */
+    function getPendingReward(
+        Parameter storage rewarder,
+        address account,
+        uint256 balance,
+        uint256 totalSupply,
+        uint256 totalRewards
+    ) internal view returns (uint256) {
+        uint256 accDebtPerShare = rewarder.accDebtPerShare + getDebtPerShare(totalSupply, totalRewards);
+
+        return balance == 0 ? 0 : getDebt(accDebtPerShare, balance) - rewarder.debt[account];
+    }
+
+    /**
+     * @dev Updates the rewarder.
+     * If the balance of the account is 0, it will always return 0.
+     * @param rewarder The storage pointer to the rewarder.
+     * @param account The address of the account.
+     * @param oldBalance The old balance of the account.
+     * @param newBalance The new balance of the account.
+     * @param totalSupply The total supply.
+     * @param totalRewards The total rewards.
+     * @return rewards The rewards of the account.
+     */
+    function update(
+        Parameter storage rewarder,
+        address account,
+        uint256 oldBalance,
+        uint256 newBalance,
+        uint256 totalSupply,
+        uint256 totalRewards
+    ) internal returns (uint256 rewards) {
+        uint256 accDebtPerShare = updateAccDebtPerShare(rewarder, totalSupply, totalRewards);
+
+        rewards = oldBalance == 0 ? 0 : getDebt(accDebtPerShare, oldBalance) - rewarder.debt[account];
+
+        rewarder.debt[account] = getDebt(accDebtPerShare, newBalance);
+    }
+
+    /**
+     * @dev Updates the accumulated debt per share.
+     * If the last update timestamp is in the future, it will not update the last update timestamp.
+     * @param rewarder The storage pointer to the rewarder.
+     * @param totalSupply The total supply.
+     * @param totalRewards The total rewards.
+     * @return The accumulated debt per share.
+     */
+    function updateAccDebtPerShare(Parameter storage rewarder, uint256 totalSupply, uint256 totalRewards)
+        internal
+        returns (uint256)
+    {
+        uint256 debtPerShare = getDebtPerShare(totalSupply, totalRewards);
+
+        if (block.timestamp > rewarder.lastUpdateTimestamp) rewarder.lastUpdateTimestamp = block.timestamp;
+
+        return debtPerShare == 0 ? rewarder.accDebtPerShare : rewarder.accDebtPerShare += debtPerShare;
+    }
+}

--- a/src/rewarders/BaseRewarder.sol
+++ b/src/rewarders/BaseRewarder.sol
@@ -5,7 +5,7 @@ import {Ownable2StepUpgradeable} from "@openzeppelin-upgradeable/contracts/acces
 import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Clone} from "@tj-dexv2/src/libraries/Clone.sol";
 
-import {Rewarder} from "../libraries/Rewarder.sol";
+import {RewarderV2} from "../libraries/RewarderV2.sol";
 import {IBaseRewarder} from "../interfaces/IBaseRewarder.sol";
 
 /**
@@ -14,7 +14,7 @@ import {IBaseRewarder} from "../interfaces/IBaseRewarder.sol";
  */
 abstract contract BaseRewarder is Ownable2StepUpgradeable, Clone, IBaseRewarder {
     using SafeERC20 for IERC20;
-    using Rewarder for Rewarder.Parameter;
+    using RewarderV2 for RewarderV2.Parameter;
 
     address public immutable implementation;
     address internal immutable _caller;
@@ -25,7 +25,7 @@ abstract contract BaseRewarder is Ownable2StepUpgradeable, Clone, IBaseRewarder 
     uint256 internal _endTimestamp;
     bool internal _isStopped;
 
-    Rewarder.Parameter internal _rewarder;
+    RewarderV2.Parameter internal _rewarder;
 
     /**
      * @dev Constructor for BaseRewarder contract.

--- a/test/libraries/RewarderV2.t.sol
+++ b/test/libraries/RewarderV2.t.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+import "../../src/libraries/RewarderV2.sol";
+
+contract RewarderV2Test is Test {
+    Amounts.Parameter amounts;
+    RewarderV2.Parameter rewarder;
+
+    address alice = makeAddr("alice");
+    address bob = makeAddr("bob");
+
+    function setUp() public {
+        Amounts.update(amounts, alice, 1e18);
+        Amounts.update(amounts, bob, 2e18);
+    }
+
+    function test_getTotalRewards(uint256 rewardPerSecond, uint256 deltaTime) public {
+        rewardPerSecond = bound(rewardPerSecond, 0, 1e36);
+        deltaTime = bound(deltaTime, 0, 1e20);
+
+        rewarder.lastUpdateTimestamp = block.timestamp - 1;
+        uint256 totalRewards = RewarderV2.getTotalRewards(rewarder, rewardPerSecond, 1);
+
+        assertEq(totalRewards, rewardPerSecond, "test_getTotalRewards::1");
+
+        rewarder.lastUpdateTimestamp = block.timestamp;
+        totalRewards = RewarderV2.getTotalRewards(rewarder, rewardPerSecond, 1);
+
+        assertEq(totalRewards, 0, "test_getTotalRewards::2");
+
+        rewarder.lastUpdateTimestamp = block.timestamp + 1;
+        totalRewards = RewarderV2.getTotalRewards(rewarder, rewardPerSecond, 1);
+
+        assertEq(totalRewards, 0, "test_getTotalRewards::3");
+
+        vm.warp(rewarder.lastUpdateTimestamp + deltaTime);
+
+        totalRewards = RewarderV2.getTotalRewards(rewarder, rewardPerSecond, 1);
+
+        assertEq(totalRewards, deltaTime * rewardPerSecond, "test_getTotalRewards::4");
+    }
+
+    function test_UpdateAccDebtPerShare() public {
+        uint256 totalSupply = 1e18;
+        uint256 totalRewards = 10e18;
+
+        uint256 addDebtPerShare = RewarderV2.updateAccDebtPerShare(rewarder, totalSupply, totalRewards);
+
+        assertEq(
+            rewarder.accDebtPerShare,
+            (totalRewards << Constants.NEW_ACC_PRECISION_BITS) / totalSupply,
+            "test_UpdateAccDebtPerShare::1"
+        );
+        assertEq(
+            RewarderV2.getDebtPerShare(totalSupply, totalRewards),
+            rewarder.accDebtPerShare,
+            "test_UpdateAccDebtPerShare::2"
+        );
+        assertEq(rewarder.lastUpdateTimestamp, block.timestamp, "test_UpdateAccDebtPerShare::3");
+
+        totalSupply = 5e18;
+        totalRewards = 5e18;
+
+        vm.warp(block.timestamp + 1);
+
+        RewarderV2.updateAccDebtPerShare(rewarder, totalSupply, totalRewards);
+
+        assertEq(
+            rewarder.accDebtPerShare,
+            addDebtPerShare + (totalRewards << Constants.NEW_ACC_PRECISION_BITS) / totalSupply,
+            "test_UpdateAccDebtPerShare::4"
+        );
+        assertEq(
+            RewarderV2.getDebtPerShare(totalSupply, totalRewards),
+            rewarder.accDebtPerShare - addDebtPerShare,
+            "test_UpdateAccDebtPerShare::5"
+        );
+        assertEq(rewarder.lastUpdateTimestamp, block.timestamp, "test_UpdateAccDebtPerShare::6");
+    }
+
+    function test_Update() public {
+        uint256 totalRewards = 10e18;
+
+        uint256 expectedRewardsAlice = RewarderV2.getPendingReward(rewarder, amounts, alice, totalRewards);
+
+        uint256 aliceRewards;
+        {
+            (uint256 oldBalance, uint256 newBalance, uint256 oldTotalSupply,) = Amounts.update(amounts, alice, 1e18);
+
+            aliceRewards = RewarderV2.update(rewarder, alice, oldBalance, newBalance, oldTotalSupply, totalRewards);
+            uint256 aliceDebt = rewarder.debt[alice];
+
+            assertEq(aliceRewards, 10e18 * oldBalance / oldTotalSupply, "test_Update::1");
+            assertEq(aliceRewards, expectedRewardsAlice, "test_Update::2");
+            assertEq(aliceDebt, 2 * aliceRewards, "test_Update::3");
+
+            expectedRewardsAlice = RewarderV2.getPendingReward(rewarder, amounts, alice, 0);
+
+            uint256 aliceRewards2 = RewarderV2.update(
+                rewarder,
+                alice,
+                Amounts.getAmountOf(amounts, alice),
+                Amounts.getAmountOf(amounts, alice),
+                Amounts.getTotalAmount(amounts),
+                0
+            );
+
+            assertEq(aliceRewards2, 0, "test_Update::4");
+            assertEq(aliceRewards2, expectedRewardsAlice, "test_Update::5");
+            assertEq(rewarder.debt[alice], aliceDebt, "test_Update::6");
+        }
+
+        uint256 expectedRewardsBob = RewarderV2.getPendingReward(rewarder, amounts, bob, 0);
+
+        uint256 bobRewards = RewarderV2.update(
+            rewarder,
+            bob,
+            Amounts.getAmountOf(amounts, bob),
+            Amounts.getAmountOf(amounts, bob),
+            Amounts.getTotalAmount(amounts),
+            0
+        );
+
+        assertEq(bobRewards, 2 * aliceRewards, "test_Update::7");
+        assertEq(bobRewards, expectedRewardsBob, "test_Update::8");
+        assertEq(rewarder.debt[bob], bobRewards, "test_Update::9");
+
+        totalRewards = 5e18;
+
+        expectedRewardsAlice = RewarderV2.getPendingReward(rewarder, amounts, alice, totalRewards);
+        expectedRewardsBob = RewarderV2.getPendingReward(rewarder, amounts, bob, totalRewards);
+
+        bobRewards = RewarderV2.update(
+            rewarder,
+            bob,
+            Amounts.getAmountOf(amounts, bob),
+            Amounts.getAmountOf(amounts, bob),
+            Amounts.getTotalAmount(amounts),
+            totalRewards
+        );
+        aliceRewards = RewarderV2.update(
+            rewarder,
+            alice,
+            Amounts.getAmountOf(amounts, alice),
+            Amounts.getAmountOf(amounts, alice),
+            Amounts.getTotalAmount(amounts),
+            0
+        );
+
+        assertEq(Amounts.getAmountOf(amounts, alice), Amounts.getAmountOf(amounts, bob), "test_Update::10");
+        assertEq(
+            aliceRewards,
+            5e18 * Amounts.getAmountOf(amounts, alice) / Amounts.getTotalAmount(amounts),
+            "test_Update::11"
+        );
+        assertEq(aliceRewards, expectedRewardsAlice, "test_Update::12");
+        assertEq(bobRewards, expectedRewardsBob, "test_Update::13");
+        assertEq(bobRewards, aliceRewards, "test_Update::14");
+        assertEq(rewarder.debt[alice], rewarder.debt[bob], "test_Update::15");
+    }
+
+    function test_UpdateAfterEmergencyWithdrawal() public {
+        uint256 totalRewards = 10e18;
+
+        uint256 rewards = RewarderV2.update(
+            rewarder,
+            alice,
+            Amounts.getAmountOf(amounts, alice),
+            Amounts.getAmountOf(amounts, alice),
+            Amounts.getTotalAmount(amounts),
+            totalRewards
+        );
+
+        assertGt(rewards, 0, "test_UpdateAfterEmergencyWithdrawal::1");
+
+        // emergency withdrawal
+        Amounts.update(amounts, bob, -int256(Amounts.getAmountOf(amounts, bob)));
+
+        uint256 expectedRewards = RewarderV2.getPendingReward(rewarder, amounts, bob, totalRewards);
+
+        (uint256 oldBalance, uint256 newBalance, uint256 oldTotalSupply,) = Amounts.update(amounts, bob, 1e18);
+        uint256 bobRewards = RewarderV2.update(rewarder, bob, oldBalance, newBalance, oldTotalSupply, totalRewards);
+
+        assertEq(bobRewards, expectedRewards, "test_UpdateAfterEmergencyWithdrawal::2");
+        assertEq(bobRewards, 0, "test_UpdateAfterEmergencyWithdrawal::3");
+    }
+
+    function test_RewarderRounding() public {
+        uint256 MAX_VALUE = 10 * 500_000_000e18 * 1_000; // 10 * max(veMoe).
+
+        uint256 accDebtPerShare1 = RewarderV2.getDebtPerShare(MAX_VALUE, 1);
+        uint256 accDebtPerShare2 = RewarderV2.getDebtPerShare(MAX_VALUE, MAX_VALUE);
+        uint256 accDebtPerShare3 = RewarderV2.getDebtPerShare(1, MAX_VALUE);
+
+        assertGt(accDebtPerShare1, 1e6, "test_RewarderRounding::1");
+        assertGt(accDebtPerShare2, 1e6, "test_RewarderRounding::2");
+        assertGt(accDebtPerShare3, 1e6, "test_RewarderRounding::3");
+
+        assertLt(accDebtPerShare1, type(uint232).max, "test_RewarderRounding::4");
+        assertLt(accDebtPerShare2, type(uint232).max, "test_RewarderRounding::5");
+        assertLt(accDebtPerShare3, type(uint232).max, "test_RewarderRounding::6");
+
+        // Due to rounding down
+        assertEq(RewarderV2.getDebt(accDebtPerShare1, MAX_VALUE), 0, "test_RewarderRounding::7");
+        assertEq(RewarderV2.getDebt(accDebtPerShare1, 1), 0, "test_RewarderRounding::11");
+
+        assertGt(RewarderV2.getDebt(accDebtPerShare2, MAX_VALUE), 1e6, "test_RewarderRounding::9");
+        assertGt(RewarderV2.getDebt(accDebtPerShare2, 1), 0, "test_RewarderRounding::12");
+
+        assertGt(RewarderV2.getDebt(accDebtPerShare3, MAX_VALUE), 1e6, "test_RewarderRounding::10");
+        assertGt(RewarderV2.getDebt(accDebtPerShare3, 1), 0, "test_RewarderRounding::13");
+    }
+}


### PR DESCRIPTION
Create a RewarderV2 with more precision to fix issues with Rewarder with very low rewardPerSeconds and high totalSupply.

**IMPORTANT** I made a `RewarderV2` instead of updating the `Rewarder` directly because it used by other upgradeable contracts (such as MasterChef, MoeStaking, VeMoe, etc...), and when upgrading those contracts, it would round down any reward not yet harvested. Using the new precision **ONLY** for new contracts is fine as they will use the same precision.